### PR TITLE
Add Anthropic Cookbook guides

### DIFF
--- a/Guides/09062025-promptfoo-evaluation-guide.md
+++ b/Guides/09062025-promptfoo-evaluation-guide.md
@@ -1,0 +1,15 @@
+# Promptfoo Evaluation Guide
+
+## Description
+Step-by-step instructions for running prompt evaluations using the Promptfoo framework with Anthropic models. Summarizes configuration, environment variables, and execution from the Anthropic Cookbook.
+
+## Source
+[Anthropic Cookbook - Evaluations with Promptfoo](https://github.com/anthropics/anthropic-cookbook/blob/main/skills/classification/evaluation/README.md)
+
+## Overview
+- Install Node.js and use `npx` to run Promptfoo without project setup.
+- Define prompts and providers in `promptfooconfig.yaml` and reference prompts in Python functions.
+- Set `ANTHROPIC_API_KEY` (and `VOYAGE_API_KEY` if needed) before running evaluations.
+- Execute `npx promptfoo@latest eval -j 25` to run tests across temperature settings and datasets.
+- Review the generated results to refine prompts and analyze accuracy.
+

--- a/Guides/09062025-voyage-ai-embeddings-guide.md
+++ b/Guides/09062025-voyage-ai-embeddings-guide.md
@@ -1,0 +1,16 @@
+# Voyage AI Embeddings Guide
+
+## Description
+Concise how-to for generating text embeddings using Voyage AI with Anthropic's API. Covers the Python client, HTTP requests, and practical retrieval examples.
+
+## Source
+[Anthropic Cookbook - How to create embeddings](https://github.com/anthropics/anthropic-cookbook/blob/main/third_party/VoyageAI/how_to_create_embeddings.md)
+
+## Overview
+- Install the `voyageai` Python package and set the `VOYAGE_API_KEY` environment variable.
+- Create a `voyageai.Client` instance to embed documents or queries.
+- Use `embed(texts, model="voyage-2", input_type="document")` for documents and `input_type="query"` for search queries.
+- Embeddings are 1,024 or 1,536 dimensional vectors depending on the model.
+- You can also call the HTTP API endpoint `https://api.voyageai.com/v1/embeddings` with JSON payloads for language-agnostic usage.
+- Combine embeddings with vector search libraries or databases to implement Retrieval-Augmented Generation (RAG).
+

--- a/Guides/README.md
+++ b/Guides/README.md
@@ -16,28 +16,32 @@ Comprehensive guides for AI tools, prompting techniques, and development workflo
 
 ### Development Tools
 - **[Cursor AI .cursorrules Guide](./08062025-cursor-ai-cursorrules-comprehensive-guide.md)** - Complete guide to Cursor AI's .cursorrules configuration system for customizing AI-powered code assistance and project-specific behavior
+- **[Promptfoo Evaluation Guide](./09062025-promptfoo-evaluation-guide.md)** - Use Promptfoo to evaluate prompts and compare Anthropic model responses
 
 ### Multi-Tool Integration
 - **[OpenAI Multi-Tool Orchestration with RAG](./08062025-openai-multi-tool-orchestration-rag-guide.md)** - Advanced guide for orchestrating multiple tools with OpenAI models, including RAG (Retrieval-Augmented Generation) implementations
+
+### Third-Party Integrations
+- **[Voyage AI Embeddings Guide](./09062025-voyage-ai-embeddings-guide.md)** - Generate embeddings with Voyage AI for use in Claude-powered RAG workflows
 
 ## Guide Categories
 
 ### By Complexity
 - **Beginner**: GPT-4.1 Prompting Guide, Prompt Repository Integration Guide
-- **Intermediate**: Advanced Prompt Engineering Techniques, Claude Tool Use Guide, Cursor AI Guide  
+- **Intermediate**: Advanced Prompt Engineering Techniques, Claude Tool Use Guide, Cursor AI Guide, Promptfoo Evaluation Guide, Voyage AI Embeddings Guide
 - **Advanced**: Multi-Tool Orchestration with RAG
 
 ### By Use Case
 - **Prompting**: Advanced Prompt Engineering Techniques, GPT-4.1 Guide
 - **Repository Management**: Prompt Repository Integration Guide
 - **API Integration**: Claude Tool Use, Multi-Tool Orchestration
-- **Development Workflow**: Cursor AI Guide
-- **Data Retrieval**: RAG Guide
+- **Development Workflow**: Cursor AI Guide, Promptfoo Evaluation Guide
+- **Data Retrieval**: RAG Guide, Voyage AI Embeddings Guide
 
 ### By Platform
 - **Cross-Platform**: Advanced Prompt Engineering Techniques, Prompt Repository Integration Guide
 - **OpenAI**: GPT-4.1 Guide, Multi-Tool Orchestration
-- **Anthropic**: Claude Tool Use Guide
+- **Anthropic**: Claude Tool Use Guide, Promptfoo Evaluation Guide, Voyage AI Embeddings Guide
 - **Cursor**: Cursor AI Configuration Guide
 
 ---

--- a/MasterREADME.md
+++ b/MasterREADME.md
@@ -2,7 +2,7 @@
 
 > Your comprehensive navigator for **1,800+ AI prompts, system prompts, and custom instructions**
 
-[![Repository Stats](https://img.shields.io/badge/Total_Files-1800+-blue)](.) [![System Prompts](https://img.shields.io/badge/System_Prompts-90+-green)](./SystemPrompts/) [![Custom Instructions](https://img.shields.io/badge/Custom_Instructions-1669+-orange)](./CustomInstructions/) [![Guides](https://img.shields.io/badge/Comprehensive_Guides-5-purple)](./Guides/)
+[![Repository Stats](https://img.shields.io/badge/Total_Files-1800+-blue)](.) [![System Prompts](https://img.shields.io/badge/System_Prompts-90+-green)](./SystemPrompts/) [![Custom Instructions](https://img.shields.io/badge/Custom_Instructions-1669+-orange)](./CustomInstructions/) [![Guides](https://img.shields.io/badge/Comprehensive_Guides-7-purple)](./Guides/)
 
 ## 🚀 Quick Navigation
 
@@ -22,7 +22,7 @@
 📂 Total Content Inventory:
 ├── 🤖 System Prompts: 90 files (Latest models from 15+ platforms)
 ├── 🎯 Custom Instructions: 1,669 files (Ready-to-use AI configurations)
-├── 📖 Comprehensive Guides: 5 files (In-depth tutorials)
+├── 📖 Comprehensive Guides: 7 files (In-depth tutorials)
 ├── 📝 Learning Articles: 6 files (Research & education)
 ├── 🔓 Advanced Techniques: 15+ files (Jailbreak & security research)
 └── 🛡️ Security Research: 50+ files (Protection & analysis)
@@ -121,6 +121,8 @@
 | **[GPT-4.1 Prompting Guide](./Guides/06082025-gpt4.1-prompting-guide.md)** | OpenAI | 🟢 Beginner | Official OpenAI guide for GPT-4.1 family models |
 | **[Claude Tool Use Guide](./Guides/08062025-claude-tool-use-comprehensive-guide.md)** | Anthropic | 🟡 Intermediate | Complete tool implementation with Claude API |
 | **[Cursor AI .cursorrules Guide](./Guides/08062025-cursor-ai-cursorrules-comprehensive-guide.md)** | Cursor | 🟡 Intermediate | AI-powered development workflow configuration |
+| **[Voyage AI Embeddings Guide](./Guides/09062025-voyage-ai-embeddings-guide.md)** | Anthropic | 🟡 Intermediate | Generate embeddings with Voyage AI for Claude RAG |
+| **[Promptfoo Evaluation Guide](./Guides/09062025-promptfoo-evaluation-guide.md)** | Anthropic | 🟡 Intermediate | Evaluate prompts using Promptfoo |
 | **[OpenAI Multi-Tool Orchestration](./Guides/08062025-openai-multi-tool-orchestration-rag-guide.md)** | OpenAI | 🔴 Advanced | RAG and multi-tool integration patterns |
 
 ---


### PR DESCRIPTION
## Summary
- add new Voyage AI embeddings guide
- add new Promptfoo evaluation guide
- index new guides in README and Master README
- update comprehensive guides count

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68490a5fb584832994c67e27f062f63c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a "Promptfoo Evaluation Guide" with step-by-step instructions for prompt evaluation using Anthropic models.
  - Added a "Voyage AI Embeddings Guide" detailing how to generate and use embeddings with Voyage AI and Anthropic's API.
  - Updated guide indexes to include the new guides, expanded categorized listings, and increased the comprehensive guide count in repository overviews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->