### PR TITLE
Add trending RSS feed endpoint

### DIFF
--- a/web_interface/README.md
+++ b/web_interface/README.md
@@ -12,6 +12,7 @@ FastAPI-powered backend and lightweight frontend for exploring **The Big Everyth
 | `/api/similar/{id}` | Semantically similar prompts |
 | `/api/collections` | Personal "garden beds" of favourite prompts |
 | `/api/llm/*` | Prompt improvement / summarisation (requires OpenRouter key) |
+| `/api/trending-feed` | Trending articles from popular networks |
 
 ---
 

--- a/web_interface/backend/app.py
+++ b/web_interface/backend/app.py
@@ -18,6 +18,14 @@ from fastapi.templating import Jinja2Templates
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
+# Optional trending RSS feed
+try:
+    from trending_feed import get_trending_feed
+    TRENDING_FEED_AVAILABLE = True
+except ImportError:
+    TRENDING_FEED_AVAILABLE = False
+    print("Trending feed not available. Install with: pip install pygooglenews")
+
 # Add the scripts directory to path to import gptparser
 REPO_ROOT = Path(__file__).parent.parent.parent
 sys.path.append(str(REPO_ROOT / ".scripts"))
@@ -1108,6 +1116,13 @@ async def get_new_sprouts_prompts(limit: int = Query(10)):
         if item:
             items.append({"prompt": item.dict(), **s})
     return items
+
+@app.get("/api/trending-feed")
+async def get_trending_feed_endpoint(limit: int = Query(10)):
+    """Return trending articles from popular networks"""
+    if not TRENDING_FEED_AVAILABLE:
+        raise HTTPException(status_code=503, detail="Trending feed library not installed")
+    return get_trending_feed(limit)
 
 @app.get("/api/discovery-signals")
 async def get_discovery_signals():

--- a/web_interface/backend/trending_feed.py
+++ b/web_interface/backend/trending_feed.py
@@ -1,0 +1,34 @@
+from datetime import datetime, timedelta
+from typing import List, Dict
+
+try:
+    from pygooglenews import GoogleNews
+except ImportError as e:
+    raise ImportError("pygooglenews is required for trending feed support") from e
+
+_cache: Dict[str, any] = {"timestamp": None, "items": []}
+
+
+def _fetch(limit: int = 10) -> List[Dict[str, str]]:
+    """Fetch trending articles from Google News RSS"""
+    gn = GoogleNews(lang='en', country='US')
+    feed = gn.top_news()
+    results = []
+    for entry in feed.get('entries', [])[:limit]:
+        results.append({
+            'title': entry.get('title'),
+            'link': entry.get('link'),
+            'published': entry.get('published'),
+            'source': entry.get('source', {}).get('title') if isinstance(entry.get('source'), dict) else None,
+        })
+    return results
+
+
+def get_trending_feed(limit: int = 10) -> List[Dict[str, str]]:
+    """Return cached trending feed, refreshing every 15 minutes"""
+    now = datetime.utcnow()
+    ts = _cache.get('timestamp')
+    if not ts or now - ts > timedelta(minutes=15):
+        _cache['items'] = _fetch(limit)
+        _cache['timestamp'] = now
+    return _cache['items'][:limit]

--- a/web_interface/requirements.txt
+++ b/web_interface/requirements.txt
@@ -19,3 +19,4 @@ python-Levenshtein==0.23.0
 markdown==3.5.1
 python-markdown-math==0.8
 pygments==2.15.1
+pygooglenews==0.1.3

--- a/web_interface/tests/test_api.py
+++ b/web_interface/tests/test_api.py
@@ -1,6 +1,7 @@
 """API endpoint tests for the Prompt Library backend."""
 
 from fastapi.testclient import TestClient
+import pytest
 
 # Import the FastAPI app
 from backend.app import app  # noqa: E402, import after adjusting path
@@ -54,3 +55,13 @@ def test_search_details():
     if data["details"]:
         detail = data["details"][0]
         assert "score" in detail and "breakdown" in detail, "Score breakdown missing"
+
+
+def test_trending_feed():
+    """Trending feed endpoint should return a list of articles."""
+    resp = client.get("/api/trending-feed")
+    if resp.status_code == 503:
+        pytest.skip("Trending feed dependency not installed")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)


### PR DESCRIPTION
## Summary
- pull trending articles via Google News RSS
- expose new `/api/trending-feed` endpoint
- document new endpoint in README
- test trending feed endpoint
- add pygooglenews dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6849185dd4b8832990352d0d467616ab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new API endpoint to provide trending news articles from popular networks.
- **Documentation**
	- Updated the README to include details about the new trending feed API endpoint.
- **Chores**
	- Added a new dependency for fetching trending news articles.
- **Tests**
	- Added tests to verify the functionality and availability of the trending feed endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->